### PR TITLE
Add charging status card to MyCarTab

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -318,6 +318,8 @@ export default function App() {
           },
           lockState: getMeasurement('LOCK_STATE_VEHICLE')?.value,
           gpsLocation: getMeasurement('GPS_LOCATION')?.value,
+          chargingSummary: getMeasurement('CHARGING_SUMMARY')?.value,
+          chargingRate: getMeasurement('CHARGING_RATE')?.value,
           tirePressure: tirePressureData ? {
             frontLeft: tirePressureData.frontLeftTire?.actualPressureBar,
             frontRight: tirePressureData.frontRightTire?.actualPressureBar,

--- a/src/components/tabs/MyCarTab.jsx
+++ b/src/components/tabs/MyCarTab.jsx
@@ -336,7 +336,8 @@ function TirePressure({ tirePressure, darkMode, units }) {
 }
 
 // Charging Component - Matches StatusCard style
-function Charging({ chargingSummary, chargingRate, darkMode, t }) {
+function Charging({ chargingSummary, chargingRate, darkMode }) {
+  const { t } = useTranslation();
   const isCharging = chargingSummary?.status === 'CHARGING';
   const powerKw = chargingRate?.chargingPower != null ? chargingRate.chargingPower : null;
   const chargeToPercent = chargingSummary?.mode === 'DIRECT'
@@ -358,7 +359,7 @@ function Charging({ chargingSummary, chargingRate, darkMode, t }) {
     ? (darkMode ? 'bg-emerald-500/20 text-emerald-400' : 'bg-emerald-100 text-emerald-600')
     : (darkMode ? 'bg-zinc-500/20 text-zinc-400' : 'bg-zinc-100 text-zinc-500');
 
-  const details = isCharging && [chargeToPercent != null && `${t('myCar.chargeTo')} ${chargeToPercent}%`, doneAtLabel].filter(Boolean);
+  const details = isCharging ? [chargeToPercent != null && `${t('myCar.chargeTo')} ${chargeToPercent}%`, doneAtLabel].filter(Boolean) : [];
 
   const mainValue = isCharging
     ? (powerKw != null ? `${Number(powerKw).toFixed(1)} kW` : t('myCar.chargingStatus'))
@@ -563,7 +564,6 @@ export function MyCarTab({
             chargingSummary={status?.chargingSummary}
             chargingRate={status?.chargingRate}
             darkMode={darkMode}
-            t={t}
           />
         </div>
 

--- a/src/i18n/translations/de.js
+++ b/src/i18n/translations/de.js
@@ -597,6 +597,11 @@ export const de = {
     tireFL: 'VL',
     tireFR: 'VR',
     tireRL: 'HL',
-    tireRR: 'HR'
+    tireRR: 'HR',
+    charging: 'Laden',
+    chargingStatus: 'Lädt',
+    notCharging: 'Lädt nicht',
+    chargeTo: 'Bis',
+    doneAt: 'Fertig um {time}'
   }
 };

--- a/src/i18n/translations/en.js
+++ b/src/i18n/translations/en.js
@@ -603,6 +603,11 @@ export const en = {
     tireFL: 'FL',
     tireFR: 'FR',
     tireRL: 'RL',
-    tireRR: 'RR'
+    tireRR: 'RR',
+    charging: 'Charging',
+    chargingStatus: 'Charging',
+    notCharging: 'Not charging',
+    chargeTo: 'To',
+    doneAt: 'Done at {time}'
   }
 };

--- a/src/i18n/translations/es.js
+++ b/src/i18n/translations/es.js
@@ -597,6 +597,11 @@ export const es = {
     tireFL: 'DI',
     tireFR: 'DD',
     tireRL: 'TI',
-    tireRR: 'TD'
+    tireRR: 'TD',
+    charging: 'Carga',
+    chargingStatus: 'Cargando',
+    notCharging: 'No cargando',
+    chargeTo: 'A',
+    doneAt: 'Listo a las {time}'
   }
 };

--- a/src/i18n/translations/fr.js
+++ b/src/i18n/translations/fr.js
@@ -597,6 +597,11 @@ export const fr = {
     tireFL: 'AVG',
     tireFR: 'AVD',
     tireRL: 'ARG',
-    tireRR: 'ARD'
+    tireRR: 'ARD',
+    charging: 'Charge',
+    chargingStatus: 'En charge',
+    notCharging: 'Pas en charge',
+    chargeTo: 'À',
+    doneAt: 'Terminé à {time}'
   }
 };

--- a/src/i18n/translations/it.js
+++ b/src/i18n/translations/it.js
@@ -597,6 +597,11 @@ export const it = {
     tireFL: 'AS',
     tireFR: 'AD',
     tireRL: 'PS',
-    tireRR: 'PD'
+    tireRR: 'PD',
+    charging: 'Ricarica',
+    chargingStatus: 'In carica',
+    notCharging: 'Non in carica',
+    chargeTo: 'A',
+    doneAt: 'Completato alle {time}'
   }
 };

--- a/src/i18n/translations/ja.js
+++ b/src/i18n/translations/ja.js
@@ -597,6 +597,11 @@ export const ja = {
     tireFL: '左前',
     tireFR: '右前',
     tireRL: '左後',
-    tireRR: '右後'
+    tireRR: '右後',
+    charging: '充電',
+    chargingStatus: '充電中',
+    notCharging: '充電していません',
+    chargeTo: 'まで',
+    doneAt: '完了 {time}'
   }
 };

--- a/src/i18n/translations/nl.js
+++ b/src/i18n/translations/nl.js
@@ -597,6 +597,11 @@ export const nl = {
     tireFL: 'VL',
     tireFR: 'VR',
     tireRL: 'AL',
-    tireRR: 'AR'
+    tireRR: 'AR',
+    charging: 'Laden',
+    chargingStatus: 'Aan het laden',
+    notCharging: 'Niet aan het laden',
+    chargeTo: 'Tot',
+    doneAt: 'Klaar om {time}'
   }
 };

--- a/src/i18n/translations/pl.js
+++ b/src/i18n/translations/pl.js
@@ -597,6 +597,11 @@ export const pl = {
     tireFL: 'PL',
     tireFR: 'PP',
     tireRL: 'TL',
-    tireRR: 'TP'
+    tireRR: 'TP',
+    charging: 'Ładowanie',
+    chargingStatus: 'Ładowanie',
+    notCharging: 'Nie ładuje',
+    chargeTo: 'Do',
+    doneAt: 'Zakończenie o {time}'
   }
 };

--- a/src/i18n/translations/pt.js
+++ b/src/i18n/translations/pt.js
@@ -602,6 +602,11 @@ export const pt = {
     tireFL: 'DE',
     tireFR: 'DD',
     tireRL: 'TE',
-    tireRR: 'TD'
+    tireRR: 'TD',
+    charging: 'Carregamento',
+    chargingStatus: 'A carregar',
+    notCharging: 'Não a carregar',
+    chargeTo: 'Até',
+    doneAt: 'Concluído às {time}'
   }
 };

--- a/src/i18n/translations/zh.js
+++ b/src/i18n/translations/zh.js
@@ -597,6 +597,11 @@ export const zh = {
     tireFL: '左前',
     tireFR: '右前',
     tireRL: '左后',
-    tireRR: '右后'
+    tireRR: '右后',
+    charging: '充电',
+    chargingStatus: '充电中',
+    notCharging: '未充电',
+    chargeTo: '至',
+    doneAt: '完成时间 {time}'
   }
 };

--- a/wiki/My-Car-Tab.md
+++ b/wiki/My-Car-Tab.md
@@ -39,6 +39,16 @@ Shows your current battery state:
 - **Estimated range** - How far you can drive on current charge
 - **Color coding** - Green (60%+), amber (30-60%), red (<30%)
 
+### Charging Card
+
+Shows current charging status when the vehicle is plugged in:
+
+- **Status** - "Charging" with the current charge rate (e.g. 8.7 kW), or "Not charging" when idle
+- **To X%** - Target charge level: from the charging profile (e.g. 75%) when mode is PROFILE, or "To 100%" when mode is DIRECT
+- **Done at [time]** - Estimated time charging will complete in your locale format
+
+The card uses data from the API's `CHARGING_SUMMARY` (status, mode, target time, profile) and `CHARGING_RATE` (charging power in kW). 
+
 ### Tire Pressure Card
 
 Displays pressure for all four tires:


### PR DESCRIPTION
- Introduced a new Charging component to display current charging status, rate, and estimated completion time.
- Updated MyCarTab layout to include the Charging card alongside existing battery and tire pressure cards.
- Enhanced translations for multiple languages to support new charging-related terms.
- Adjusted CSS classes for consistent alignment in card components.

![charging card](https://github.com/user-attachments/assets/fc8606a4-6df4-46af-a185-d0a03f5077cb)

Fixes #3 